### PR TITLE
Ft period grace exceeds 30days 148476591

### DIFF
--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -19,8 +19,8 @@ class NameTagsForm(forms.Form):
 
 
 class TimeoutForm(forms.Form):
-    timeout = forms.IntegerField(min_value=60, max_value=2592000)
-    grace = forms.IntegerField(min_value=60, max_value=2592000)
+    timeout = forms.IntegerField(min_value=60, max_value=7776000)
+    grace = forms.IntegerField(min_value=60, max_value=7776000)
 
 
 class CronForm(forms.Form):

--- a/static/js/checks.js
+++ b/static/js/checks.js
@@ -10,6 +10,7 @@ $(function () {
         return false;
     });
 
+    var SECONDS_IN_MONTH = 2592000
     var MINUTE = {name: "minute", nsecs: 60};
     var HOUR = {name: "hour", nsecs: MINUTE.nsecs * 60};
     var DAY = {name: "day", nsecs: HOUR.nsecs * 24};
@@ -40,20 +41,23 @@ $(function () {
         return result;
     }
 
+    var slider_values = [60, 3600, 86400, 604800, SECONDS_IN_MONTH, (SECONDS_IN_MONTH * 2), (SECONDS_IN_MONTH * 3)]
+
     var periodSlider = document.getElementById("period-slider");
     noUiSlider.create(periodSlider, {
         start: [20],
         connect: "lower",
         range: {
-            'min': [60, 60],
-            '33%': [3600, 3600],
-            '66%': [86400, 86400],
-            '83%': [604800, 604800],
-            'max': 2592000,
+            'min': 60,
+            '20%': 1800,
+            '35%': 43200,
+            '50%': 604800,
+            '80%': (2592000 * 2),
+            'max': (2592000 * 3)
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: slider_values,
             density: 4,
             format: {
                 to: secsToText,
@@ -73,15 +77,16 @@ $(function () {
         start: [20],
         connect: "lower",
         range: {
-            'min': [60, 60],
-            '33%': [3600, 3600],
-            '66%': [86400, 86400],
-            '83%': [604800, 604800],
-            'max': 2592000,
+            'min': 60,
+            '20%': 1800,
+            '35%': 43200,
+            '50%': 604800,
+            '80%': (2592000 * 2),
+            'max': (2592000 * 3)
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: slider_values,
             density: 4,
             format: {
                 to: secsToText,


### PR DESCRIPTION
## What does this PR do?
A user of healthchecks can set a timeout(period) and grace that exceeds 30 days. The maximum limit is 90 days

## Description of task given
User should be able to set timeouts and grace values for days exceeding 30

## Relevant pivotal tracker story
 148476591
