### PR TITLE
Ft alert often jobs 148476593

### DIFF
--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -19,14 +19,15 @@ STATUSES = (
     ("up", "Up"),
     ("down", "Down"),
     ("new", "New"),
-    ("paused", "Paused")
+    ("paused", "Paused"),
+    ("early", "Early")
 )
 
 STATUS = (
     ("up", "Up"),
     ("down", "Down"),
     ("new", "New"),
-    ("nag", "Nag")
+    ("nag", "Nag"),
 )
 
 DEFAULT_TIMEOUT = td(days=1)
@@ -98,7 +99,7 @@ class Check(models.Model):
         return int(h) * 3600 + int(m) * 60 + int(s)
 
     def send_alert(self):
-        if self.status not in ("up", "down"):
+        if self.status not in ("up", "down", "nag", "early"):
             raise NotImplementedError("Unexpected status: %s" % self.status)
 
         errors = []
@@ -126,10 +127,19 @@ class Check(models.Model):
             next_naive = it.get_next(datetime)
             return timezone.make_aware(next_naive, is_dst=False)
 
+    def check_job_runs_early(self):
+        if timezone.now() - self.last_ping < self.timeout - self.grace:
+            self.status = "early"
+            self.save()
+            self.refresh_from_db()
+            self.send_alert()
+        else:
+            pass
+
     def get_status(self, now=None):
         """ Return "up" if the check is up or in grace, otherwise "down". """
 
-        if self.status in ("new", "paused"):
+        if self.status in ("new", "paused", "early"):
             return self.status
 
         if now is None:

--- a/hc/api/views.py
+++ b/hc/api/views.py
@@ -26,6 +26,8 @@ def ping(request, code):
     check.alert_after = check.get_alert_after()
     if check.status in ("new", "paused"):
         check.status = "up"
+    else:
+        early = check.check_job_runs_early()
 
     check.save()
     check.refresh_from_db()

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -123,7 +123,8 @@ USE_L10N = True
 
 USE_TZ = True
 
-SITE_ROOT = "https://demo-healthchecks.herokuapp.com"
+SITE_ROOT = "http://localhost:8000"
+# SITE_ROOT = "https://demo-healthchecks.herokuapp.com"
 SITE_NAME = "healthchecks.io"
 PING_ENDPOINT = SITE_ROOT + "/ping/"
 PING_EMAIL_DOMAIN = HOST
@@ -139,7 +140,7 @@ COMPRESS_OFFLINE = True
 
 #EMAIL_BACKEND = "djmail.backends.default.EmailBackend"
 EMAIL_BACKEND = "sgbackend.SendGridBackend"
-SENDGRID_API_KEY = "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"
+SENDGRID_API_KEY = "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"
 
 # Discord integration -- override these in local_settings
 DISCORD_CLIENT_ID = None

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -123,8 +123,8 @@ USE_L10N = True
 
 USE_TZ = True
 
-SITE_ROOT = "http://localhost:8000"
-# SITE_ROOT = "https://demo-healthchecks.herokuapp.com"
+# SITE_ROOT = "http://localhost:8000"
+SITE_ROOT = "https://demo-healthchecks.herokuapp.com"
 SITE_NAME = "healthchecks.io"
 PING_ENDPOINT = SITE_ROOT + "/ping/"
 PING_EMAIL_DOMAIN = HOST

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -124,7 +124,7 @@ USE_L10N = True
 USE_TZ = True
 
 # SITE_ROOT = "http://localhost:8000"
-SITE_ROOT = "https://demo-healthchecks.herokuapp.com"
+SITE_ROOT = "http://prometheus-often.herokuapp.com/"
 SITE_NAME = "healthchecks.io"
 PING_ENDPOINT = SITE_ROOT + "/ping/"
 PING_EMAIL_DOMAIN = HOST

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -61,6 +61,7 @@ body {
 .status.icon-up.new, .status.icon-paused { color: #CCC; }
 .status.icon-grace { color: #f0ad4e; }
 .status.icon-down { color: #d9534f; }
+.status.icon-early {color: #d9534f}
 
 .hc-dialog {
     background: #FFF;

--- a/static/css/icomoon.css
+++ b/static/css/icomoon.css
@@ -36,6 +36,9 @@
 .icon-up:before {
   content: "\e86c";
 }
+.icon-early:before {
+  content: "\e86c";
+}
 .icon-close:before {
   content: "\e5cd";
 }

--- a/templates/front/my_checks.html
+++ b/templates/front/my_checks.html
@@ -25,6 +25,7 @@
             <li><a href="{% url 'hc-checks' %}?status=new">New Jobs</a></li>
             <li><a href="{% url 'hc-checks' %}?status=up">Up Jobs</a></li>
             <li><a href="{% url 'hc-checks' %}?status=paused">Paused</a></li>
+            <li><a href="{% url 'hc-checks' %}?status=early">Early Jobs</a></li>
             <li><a href="{% url 'hc-checks' %}?status=down">Failed Jobs</a></li>
           </ul>
         </div>

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -28,6 +28,8 @@
                 <span class="status icon-mail"></span>
             {% elif check.get_status == "down" %}
                 <span class="status icon-down"></span>
+            {% elif check.get_status == "early" %}
+                <span class="status icon-early"></span>
             {% endif %}
         </td>
         <td class="name-cell">


### PR DESCRIPTION
#### What does this PR do?
- It notifies the user when the job is run too often.
#### Description of Task to be completed?
- A job can be considered as running too often when it is run before the set Timeout period. 
- The user is notified when the job runs before the specified time.
- The icon status turns red to indicate that a job before the specified period 
#### How should this be manually tested?
- On the dashboard create a job.
- ping the job once to set the first ping.
- ping it the second time and you will be notified that it has run early.
#### Any background context you want to provide?
- To switch the job from early, you have to pause it and then ping it to set the ping.
#### What are the relevant pivotal tracker stories?
- #148476593 -- User should be notified when a job is run too often
#### Screenshots
- Ping a new job. Icon color is green, in this example. Test runner is green
<img width="1438" alt="screen shot 2017-08-17 at 09 00 39" src="https://user-images.githubusercontent.com/29260246/29398054-e09bd332-832a-11e7-9845-bfbb651677f1.png">
- Ping the job again before its scheduled time. Icon color changes to red
<img width="1416" alt="screen shot 2017-08-17 at 09 01 25" src="https://user-images.githubusercontent.com/29260246/29398103-345975f6-832b-11e7-98c5-47760ea41b6c.png">


